### PR TITLE
Make APIClientDelegate functions throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ One of the ways you can customize the client is by providing a custom delegate i
 
 ```swift
 final class AuthorizingDelegate: APIClientDelegate {    
-    func client(_ client: APIClient, willSendRequest request: inout URLRequest) async {
+    func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
         request.allHTTPHeaderFields = ["Authorization": "Bearer: \(token)"]
     }
     

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ final class AuthorizingDelegate: APIClientDelegate {
         request.allHTTPHeaderFields = ["Authorization": "Bearer: \(token)"]
     }
     
-    func shouldClientRetry(_ client: APIClient, withError error: Error) async -> Bool {
+    func shouldClientRetry(_ client: APIClient, withError error: Error) async throws -> Bool {
         if case .unacceptableStatusCode(let statusCode) = (error as? APIError), statusCode == 401 {
             return await refreshAccessToken()
         }

--- a/Sources/Get/APIClient.swift
+++ b/Sources/Get/APIClient.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public protocol APIClientDelegate {
     func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws
-    func shouldClientRetry(_ client: APIClient, withError error: Error) async -> Bool
+    func shouldClientRetry(_ client: APIClient, withError error: Error) async throws -> Bool
     func client(_ client: APIClient, didReceiveInvalidResponse response: HTTPURLResponse, data: Data) -> Error
 }
 
@@ -108,7 +108,7 @@ public actor APIClient {
         do {
             return try await actuallySend(request)
         } catch {
-            guard await delegate.shouldClientRetry(self, withError: error) else { throw error }
+            guard try await delegate.shouldClientRetry(self, withError: error) else { throw error }
             return try await actuallySend(request)
         }
     }
@@ -180,7 +180,7 @@ public enum APIError: Error, LocalizedError {
 
 public extension APIClientDelegate {
     func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {}
-    func shouldClientRetry(_ client: APIClient, withError error: Error) async -> Bool { false }
+    func shouldClientRetry(_ client: APIClient, withError error: Error) async throws -> Bool { false }
     func client(_ client: APIClient, didReceiveInvalidResponse response: HTTPURLResponse, data: Data) -> Error {
         APIError.unacceptableStatusCode(response.statusCode)
     }

--- a/Tests/GetTests/ClientAuthorizationTests.swift
+++ b/Tests/GetTests/ClientAuthorizationTests.swift
@@ -18,45 +18,93 @@ final class APIClientAuthorizationTests: XCTestCase {
             $0.sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
         }
     }
-    
-    func testAuthorizationHeaderIsPassed() async throws {
-        // GIVEN
-        let url = URL(string: "https://api.github.com/user")!
-        var mock = Mock(url: url, dataType: .json, statusCode: 401, data: [
-            .get: "Unauthorized".data(using: .utf8)!
-        ])
-        
-        mock.onRequest = { request, arguments in
-            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer: expired-token")
 
-            self.delegate.token = "valid-token"
-            var mock = Mock.get(url: url, json: "user")
-            mock.onRequest = { request, arguments in
-                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer: valid-token")
-            }
-            mock.register()
+    func testAuthorizationHeaderWidhValidToken() async throws {
+        // GIVEN
+        delegate.token = Token(value: "valid-token", expiresDate: Date(timeIntervalSinceNow: 1000))
+        let url = URL(string: "https://api.github.com/user")!
+        var mock = Mock.get(url: url, json: "user")
+        mock.onRequest = { request, arguments in
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer valid-token")
+        }
+        mock.register()
+
+        // WHEN
+        try await client.send(.get("/user"))
+    }
+    
+    func testAuthorizationHeaderWithExpiredToken() async throws {
+        // GIVEN
+        delegate.token = Token(value: "expired-token", expiresDate: Date(timeIntervalSinceNow: -1000))
+        let url = URL(string: "https://api.github.com/user")!
+        var mock = Mock.get(url: url, json: "user")
+        mock.onRequest = { request, arguments in
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer valid-token")
         }
         mock.register()
         
         // WHEN
-        let user: User = try await client.send(.get("/user")).value
-                                               
-        // THEN
-        XCTAssertEqual(user.login, "kean")
+        try await client.send(.get("/user"))
+    }
+
+    func testAuthorizationHeaderWithInvalidToken() async throws {
+        // GIVEN
+        delegate.token = Token(value: "invalid-token", expiresDate: Date(timeIntervalSinceNow: 1000))
+        let url = URL(string: "https://api.github.com/user")!
+        var mock = Mock(url: url, dataType: .json, statusCode: 401, data: [
+            .get: "Unauthorized".data(using: .utf8)!
+        ])
+        mock.onRequest = { request, arguments in
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer invalid-token")
+
+            var mock = Mock.get(url: url, json: "user")
+            mock.onRequest = { request, arguments in
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer valid-token")
+            }
+            mock.register()
+        }
+        mock.register()
+
+        // WHEN
+        try await client.send(.get("/user"))
     }
 }
 
 private final class MockAuthorizingDelegate: APIClientDelegate {
-    var token = "expired-token"
-    
+    var token: Token!
+    let tokenRefresher = TokenRefresher()
+
     func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
-        request.allHTTPHeaderFields = ["Authorization": "Bearer: \(token)"]
+        let now = Date()
+
+        // Refresh the token if it has expired.
+        if token.expiresDate < now {
+            token = try await tokenRefresher.refreshToken()
+        }
+
+        request.addValue("Bearer \(token.value)", forHTTPHeaderField: "Authorization")
     }
     
-    func shouldClientRetry(_ client: APIClient, withError error: Error) async -> Bool {
+    func shouldClientRetry(_ client: APIClient, withError error: Error) async throws -> Bool {
         if case .unacceptableStatusCode(let statusCode) = (error as? APIError), statusCode == 401 {
+            token = try await tokenRefresher.refreshToken()
             return true
         }
         return false
+    }
+}
+
+private struct Token {
+    /// Value for authorization header.
+    var value: String
+    /// Expiration date of the token. Even within the expiration date,the token may
+    /// have been invalidated in the server.
+    var expiresDate: Date
+}
+
+private struct TokenRefresher {
+    func refreshToken() async throws -> Token {
+        // TODO: Refresh (make sure you only refresh once if multiple requests fail)
+        Token(value: "valid-token", expiresDate: Date(timeIntervalSinceNow: 1000))
     }
 }

--- a/Tests/GetTests/ClientAuthorizationTests.swift
+++ b/Tests/GetTests/ClientAuthorizationTests.swift
@@ -25,7 +25,7 @@ final class APIClientAuthorizationTests: XCTestCase {
         let url = URL(string: "https://api.github.com/user")!
         var mock = Mock.get(url: url, json: "user")
         mock.onRequest = { request, arguments in
-            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer valid-token")
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "token valid-token")
         }
         mock.register()
 
@@ -39,7 +39,7 @@ final class APIClientAuthorizationTests: XCTestCase {
         let url = URL(string: "https://api.github.com/user")!
         var mock = Mock.get(url: url, json: "user")
         mock.onRequest = { request, arguments in
-            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer valid-token")
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "token valid-token")
         }
         mock.register()
         
@@ -55,11 +55,11 @@ final class APIClientAuthorizationTests: XCTestCase {
             .get: "Unauthorized".data(using: .utf8)!
         ])
         mock.onRequest = { request, arguments in
-            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer invalid-token")
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "token invalid-token")
 
             var mock = Mock.get(url: url, json: "user")
             mock.onRequest = { request, arguments in
-                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer valid-token")
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "token valid-token")
             }
             mock.register()
         }
@@ -82,7 +82,7 @@ private final class MockAuthorizingDelegate: APIClientDelegate {
             token = try await tokenRefresher.refreshToken()
         }
 
-        request.addValue("Bearer \(token.value)", forHTTPHeaderField: "Authorization")
+        request.addValue("token \(token.value)", forHTTPHeaderField: "Authorization")
     }
     
     func shouldClientRetry(_ client: APIClient, withError error: Error) async throws -> Bool {

--- a/Tests/GetTests/ClientAuthorizationTests.swift
+++ b/Tests/GetTests/ClientAuthorizationTests.swift
@@ -49,7 +49,7 @@ final class APIClientAuthorizationTests: XCTestCase {
 private final class MockAuthorizingDelegate: APIClientDelegate {
     var token = "expired-token"
     
-    func client(_ client: APIClient, willSendRequest request: inout URLRequest) async {
+    func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
         request.allHTTPHeaderFields = ["Authorization": "Bearer: \(token)"]
     }
     

--- a/Tests/GetTests/GitHubAPI.swift
+++ b/Tests/GetTests/GitHubAPI.swift
@@ -92,7 +92,7 @@ enum GitHubError: Error {
 }
 
 private final class GitHubAPIClientDelegate: APIClientDelegate {
-    func client(_ client: APIClient, willSendRequest request: inout URLRequest) {
+    func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
         request.setValue("Bearer: \("your-access-token")", forHTTPHeaderField: "Authorization")
     }
         

--- a/Tests/GetTests/GitHubAPI.swift
+++ b/Tests/GetTests/GitHubAPI.swift
@@ -96,7 +96,7 @@ private final class GitHubAPIClientDelegate: APIClientDelegate {
         request.setValue("Bearer: \("your-access-token")", forHTTPHeaderField: "Authorization")
     }
         
-    func shouldClientRetry(_ client: APIClient, withError error: Error) async -> Bool {
+    func shouldClientRetry(_ client: APIClient, withError error: Error) async throws -> Bool {
         if case .unacceptableStatusCode(let status) = (error as? GitHubError), status == 401 {
             return await refreshAccessToken()
         }


### PR DESCRIPTION
In my usage, I sometimes use `willSendRequest` and `shouldClientRetry` to call the API to refresh the token.

Since the API is asynchronous and throwable, I want to make `willSendRequest` and `shouldClientRetry` throwable.